### PR TITLE
Expose metadata in BrainToText2025Dataset

### DIFF
--- a/data_prepration/2025/download_data.py
+++ b/data_prepration/2025/download_data.py
@@ -1,0 +1,60 @@
+"""Download Brain-to-Text 2025 dataset from Dryad."""
+
+import os
+import sys
+import urllib.request
+import json
+import zipfile
+
+
+def display_progress_bar(block_num, block_size, total_size, message=""):
+    bytes_downloaded_so_far = block_num * block_size
+    MB_downloaded_so_far = bytes_downloaded_so_far / 1e6
+    MB_total = total_size / 1e6
+    sys.stdout.write(
+        f"\r{message}\t\t{MB_downloaded_so_far:.1f} MB / {MB_total:.1f} MB"
+    )
+    sys.stdout.flush()
+
+
+def download_dataset(data_dir="data", doi="10.5061/dryad.dncjsxm85"):
+    """Download all files associated with the given Dryad DOI."""
+    DRYAD_ROOT = "https://datadryad.org"
+    data_dirpath = os.path.abspath(data_dir)
+    os.makedirs(data_dirpath, exist_ok=True)
+
+    urlified_doi = doi.replace("/", "%2F")
+    versions_url = f"{DRYAD_ROOT}/api/v2/datasets/doi:{urlified_doi}/versions"
+    with urllib.request.urlopen(versions_url) as response:
+        versions_info = json.loads(response.read().decode())
+
+    files_url_path = versions_info["_embedded"]["stash:versions"][-1]["_links"]["stash:files"]["href"]
+    files_url = f"{DRYAD_ROOT}{files_url_path}"
+    with urllib.request.urlopen(files_url) as response:
+        files_info = json.loads(response.read().decode())
+
+    for file_info in files_info["_embedded"]["stash:files"]:
+        filename = file_info["path"]
+        if filename == "README.md":
+            continue
+
+        download_path = file_info["_links"]["stash:download"]["href"]
+        download_url = f"{DRYAD_ROOT}{download_path}"
+        download_to = os.path.join(data_dirpath, filename)
+        urllib.request.urlretrieve(
+            download_url,
+            download_to,
+            reporthook=lambda *args: display_progress_bar(*args, message=f"Downloading {filename}")
+        )
+        sys.stdout.write("\n")
+
+        if file_info["mimeType"] == "application/zip":
+            print(f"Extracting files from {filename} ...")
+            with zipfile.ZipFile(download_to, "r") as zf:
+                zf.extractall(data_dirpath)
+
+    print(f"\nDownload complete. See data files in {data_dirpath}\n")
+
+
+if __name__ == "__main__":
+    download_dataset()

--- a/data_prepration/2025/prepare_data.py
+++ b/data_prepration/2025/prepare_data.py
@@ -1,0 +1,77 @@
+"""Utilities for loading Brain-to-Text 2025 HDF5 data."""
+
+from pathlib import Path
+import h5py
+import torch
+from torch.utils.data import Dataset
+from torch.nn.utils.rnn import pad_sequence
+
+
+class BrainToText2025Dataset(Dataset):
+    """Iterates over all trials contained in Brain-to-Text 2025 sessions."""
+
+    def __init__(self, data_dir):
+        self.session_paths = sorted(Path(data_dir).glob("hdf5_data_final/*/*.hdf5"))
+        self.trial_index = []
+        for session_path in self.session_paths:
+            with h5py.File(session_path, "r") as f:
+                for trial_key in f.keys():
+                    self.trial_index.append((session_path, trial_key))
+
+    def __len__(self):
+        return len(self.trial_index)
+
+    def __getitem__(self, idx):
+        session_path, trial_key = self.trial_index[idx]
+        with h5py.File(session_path, "r") as f:
+            g = f[trial_key]
+            sample = {
+                "input_features": torch.from_numpy(g["input_features"][:]),
+                "seq_class_ids": torch.from_numpy(g["seq_class_ids"][:]),
+                "transcription": "".join(map(chr, g["transcription"][:])),
+                "n_time_steps": int(g.attrs["n_time_steps"]),
+                "seq_len": int(g.attrs["seq_len"]),
+                "block_num": int(g.attrs["block_num"]),
+                "trial_num": int(g.attrs["trial_num"]),
+            }
+        return sample
+
+
+def collate_batch(batch):
+    features = [b["input_features"] for b in batch]
+    labels = [b["seq_class_ids"] for b in batch]
+    transcriptions = [b["transcription"] for b in batch]
+    n_time_steps = [b["n_time_steps"] for b in batch]
+    seq_lens = [b["seq_len"] for b in batch]
+    block_nums = [b["block_num"] for b in batch]
+    trial_nums = [b["trial_num"] for b in batch]
+
+    return {
+        "input_features": pad_sequence(features, batch_first=True, padding_value=0),
+        "seq_class_ids": pad_sequence(labels, batch_first=True, padding_value=0),
+        "transcriptions": transcriptions,
+        "n_time_steps": torch.tensor(n_time_steps),
+        "seq_lens": torch.tensor(seq_lens),
+        "block_nums": torch.tensor(block_nums),
+        "trial_nums": torch.tensor(trial_nums),
+    }
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Load Brain-to-Text 2025 data and print a summary."
+    )
+    parser.add_argument(
+        "data_dir", help="Directory containing the hdf5_data_final folder"
+    )
+    args = parser.parse_args()
+
+    dataset = BrainToText2025Dataset(args.data_dir)
+    print(f"Found {len(dataset)} trials across {len(dataset.session_paths)} sessions.")
+    sample = dataset[0]
+    print("Sample feature shape:", sample["input_features"].shape)
+    print("Sample label length:", len(sample["seq_class_ids"]))
+    print("Sample transcription:", sample["transcription"])
+    print("Sample n_time_steps:", sample["n_time_steps"])

--- a/data_prepration/2025/requirements.txt
+++ b/data_prepration/2025/requirements.txt
@@ -1,0 +1,5 @@
+h5py
+numpy
+torch
+requests
+tqdm


### PR DESCRIPTION
## Summary
- Return metadata like transcriptions, timing, and identifiers from BrainToText2025Dataset
- Collate function now builds padded batches and gathers per-trial metadata
- CLI example prints sample transcription and timing info

## Testing
- `python -m py_compile data_prepration/2025/download_data.py data_prepration/2025/prepare_data.py`


------
https://chatgpt.com/codex/tasks/task_e_689ed9e1801483248af86403fe0e7f12