### PR TITLE
Add diphone sequences to dataloader output

### DIFF
--- a/model_training/rnn_trainer.py
+++ b/model_training/rnn_trainer.py
@@ -519,6 +519,7 @@ class BrainToTextDecoder_Trainer:
             # Move data to device
             features = batch['input_features'].to(self.device)
             labels = batch['seq_class_ids'].to(self.device)
+            diphone_labels = batch['diphone_seq_ids'].to(self.device)
             n_time_steps = batch['n_time_steps'].to(self.device)
             phone_seq_lens = batch['phone_seq_lens'].to(self.device)
             day_indicies = batch['day_indicies'].to(self.device)
@@ -688,6 +689,7 @@ class BrainToTextDecoder_Trainer:
 
             features = batch['input_features'].to(self.device)
             labels = batch['seq_class_ids'].to(self.device)
+            diphone_labels = batch['diphone_seq_ids'].to(self.device)
             n_time_steps = batch['n_time_steps'].to(self.device)
             phone_seq_lens = batch['phone_seq_lens'].to(self.device)
             day_indicies = batch['day_indicies'].to(self.device)


### PR DESCRIPTION
## Summary
- dataloader returns diphone transitions with self-repeats and repeated phoneme targets
- training loop still receives diphone sequences for future use

## Testing
- `python -m py_compile model_training/dataset.py model_training/rnn_trainer.py`


------
https://chatgpt.com/codex/tasks/task_e_689f1d0e43c88324ae21238b0602b923